### PR TITLE
README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Building FIES
 ```splus
 CF=$(xml2-config --cflags)
 LF=$(xml2-config --libs)
-./configure --target-list=arm-softmmu --extra-cflags=$CF --extra-ldflags=$LF --enable-sdl
+./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --enable-sdl 
 cd pixman
 ./configure
 cd ..

--- a/README.md
+++ b/README.md
@@ -119,11 +119,11 @@ XML Fields:
 * `<duration>`: duration for intemittend and transient faults in ms (e.g. `10MS`)
 * `<interval>`: interval for intermittent faults in ms (e.g. `10MS`)
 * `<params>`: parameter descriptions to specify fault mode
-  *`<address>`: register or memory address
-  *`<mask>`: mask for the position where fault should be active (e.g. to inject fault in last bit `0x1`), or new value definition in `NEW VALUE` mode
-  *`<cf_address>`: coupling addrsss for coupling faults
-  *`<instruction>`: instruction number that should be replaced for `CPU INSTRUCTION DECODER` faults 
-  *`<set_bit>`: mask to select if bits defined in `<mask>` should be set (e.g. `0x1` for SAF-1) or resetted (e.g. `0x0` for SAF-0). Aggressor-bit mask for intercoupling faults.
+  * `<address>`: register or memory address
+  * `<mask>`: mask for the position where fault should be active (e.g. to inject fault in last bit `0x1`), or new value definition in `NEW VALUE` mode
+  * `<cf_address>`: coupling addrsss for coupling faults
+  * `<instruction>`: instruction number that should be replaced for `CPU INSTRUCTION DECODER` faults 
+  * `<set_bit>`: mask to select if bits defined in `<mask>` should be set (e.g. `0x1` for SAF-1) or resetted (e.g. `0x0` for SAF-0). Aggressor-bit mask for intercoupling faults.
 
 #### Execute software and inject fault
 Use the `-fi` flag to give the fault library and start FIES with fault injection

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Building FIES
 ```splus
 CF=$(xml2-config --cflags)
 LF=$(xml2-config --libs)
-./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --enable-sdl 
+PP=$(which python2)
+./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --python="$PP" --enable-sdl
 cd pixman
 ./configure
 cd ..

--- a/fies_sandbox/README.md
+++ b/fies_sandbox/README.md
@@ -17,7 +17,7 @@ Building FIES
 ```splus
 CF=$(xml2-config --cflags)
 LF=$(xml2-config --libs)
-./configure --target-list=arm-softmmu --extra-cflags=$CF --extra-ldflags=$LF --enable-sdl
+./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --enable-sdl
 cd pixman
 ./configure
 cd ..

--- a/fies_sandbox/README.md
+++ b/fies_sandbox/README.md
@@ -17,7 +17,8 @@ Building FIES
 ```splus
 CF=$(xml2-config --cflags)
 LF=$(xml2-config --libs)
-./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --enable-sdl
+PP=$(which python2)
+./configure --target-list=arm-softmmu --extra-cflags="$CF" --extra-ldflags="$LF" --python="$PP" --enable-sdl
 cd pixman
 ./configure
 cd ..

--- a/fies_sandbox/README.md
+++ b/fies_sandbox/README.md
@@ -96,8 +96,8 @@ XML fault lib example:
 ```
 
 XML Fields:
-*`<fault>`: Defines start and end of fault description. Multiple faults are injected concurrently if multiple fault descriptions are provided.
-*`<id>`: Defines fault ID
-*`<component>`: Defines the victim component (`CPU`, `RAM`, or `REGISTER`)
-*`<target>`: Defines the target point of a fault as follows...
-**for `CPU` faults: `INSTRUCTION DECODER`, `INSTRUCTION EXECUTION`, or `CONDITION FLAGS`
+* `<fault>`: Defines start and end of fault description. Multiple faults are injected concurrently if multiple fault descriptions are provided.
+* `<id>`: Defines fault ID
+* `<component>`: Defines the victim component (`CPU`, `RAM`, or `REGISTER`)
+* `<target>`: Defines the target point of a fault as follows...
+  * for `CPU` faults: `INSTRUCTION DECODER`, `INSTRUCTION EXECUTION`, or `CONDITION FLAGS`


### PR DESCRIPTION
Fix README configure params (set path to python2 and use quotes on CF/LF variables) and fix list format (there was not space between star and text)